### PR TITLE
Compatibility with python 3

### DIFF
--- a/biosppy/__init__.py
+++ b/biosppy/__init__.py
@@ -11,3 +11,4 @@
 
 # get version
 from .version import version as __version__
+from .signals import *

--- a/biosppy/__init__.py
+++ b/biosppy/__init__.py
@@ -17,4 +17,4 @@ from .signals.ecg import *
 from .signals.eda import *
 from .signals.eeg import *
 from .signals.emg import *
-from .signals.rsp import *
+from .signals.resp import *

--- a/biosppy/__init__.py
+++ b/biosppy/__init__.py
@@ -11,4 +11,10 @@
 
 # get version
 from .version import version as __version__
-from .signals import *
+
+# Lazy load
+from .signals.ecg import *
+from .signals.eda import *
+from .signals.eeg import *
+from .signals.emg import *
+from .signals.rsp import *

--- a/biosppy/signals/ecg.py
+++ b/biosppy/signals/ecg.py
@@ -117,7 +117,7 @@ def ecg(signal=None, sampling_rate=1000., show=True):
     names = ('ts', 'filtered', 'rpeaks', 'templates_ts', 'templates',
              'heart_rate_ts', 'heart_rate')
 
-    return utils.ReturnTuple(args, names)
+    return(ts, filtered, rpeaks, ts_tmpl, templates, ts_hr, hr)
 
 
 def _extract_heartbeats(signal=None, rpeaks=None, before=200, after=400):
@@ -163,7 +163,7 @@ def _extract_heartbeats(signal=None, rpeaks=None, before=200, after=400):
     templates = np.array(templates)
     newR = np.array(newR, dtype='int')
 
-    return templates, newR
+    return(templates, newR)
 
 
 def extract_heartbeats(signal=None, rpeaks=None, sampling_rate=1000.,
@@ -216,7 +216,7 @@ def extract_heartbeats(signal=None, rpeaks=None, sampling_rate=1000.,
                                           before=before,
                                           after=after)
 
-    return utils.ReturnTuple((templates, newR), ('templates', 'rpeaks'))
+    return(templates, newR)
 
 
 def compare_segmentation(reference=None, test=None, sampling_rate=1000.,
@@ -384,7 +384,7 @@ def compare_segmentation(reference=None, test=None, sampling_rate=1000.,
              'mean_deviation', 'std_deviation', 'mean_ref_ibi', 'std_ref_ibi',
              'mean_test_ibi', 'std_test_ibi',)
 
-    return utils.ReturnTuple(args, names)
+    return(TP, FP, perf, acc, err, matchIdx, dev, mdev, sdev, rIBIm, rIBIs, tIBIm, tIBIs)
 
 
 def ssf_segmenter(signal=None, sampling_rate=1000., threshold=20, before=0.03,
@@ -450,7 +450,7 @@ def ssf_segmenter(signal=None, sampling_rate=1000., threshold=20, before=0.03,
     rpeaks.sort()
     rpeaks = np.array(rpeaks, dtype='int')
 
-    return utils.ReturnTuple((rpeaks,), ('rpeaks',))
+    return(rpeaks)
 
 
 def christov_segmenter(signal=None, sampling_rate=1000.):
@@ -616,7 +616,7 @@ def christov_segmenter(signal=None, sampling_rate=1000.):
     rpeaks = sorted(list(set(rpeaks)))
     rpeaks = np.array(rpeaks, dtype='int')
 
-    return utils.ReturnTuple((rpeaks,), ('rpeaks',))
+    return(rpeaks)
 
 
 def engzee_segmenter(signal=None, sampling_rate=1000., threshold=0.48):
@@ -770,7 +770,7 @@ def engzee_segmenter(signal=None, sampling_rate=1000., threshold=0.48):
     rpeaks = sorted(list(set(rpeaks)))
     rpeaks = np.array(rpeaks, dtype='int')
 
-    return utils.ReturnTuple((rpeaks,), ('rpeaks',))
+    return(rpeaks)
 
 
 def gamboa_segmenter(signal=None, sampling_rate=1000., tol=0.002):
@@ -830,7 +830,7 @@ def gamboa_segmenter(signal=None, sampling_rate=1000., tol=0.002):
 
     rpeaks = np.array(rpeaks, dtype='int')
 
-    return utils.ReturnTuple((rpeaks,), ('rpeaks',))
+    return(rpeaks)
 
 
 def hamilton_segmenter(signal=None, sampling_rate=1000.):
@@ -1136,4 +1136,4 @@ def hamilton_segmenter(signal=None, sampling_rate=1000.):
     rpeaks = sorted(list(set(r_beats)))
     rpeaks = np.array(rpeaks, dtype='int')
 
-    return utils.ReturnTuple((rpeaks,), ('rpeaks',))
+    return(rpeaks)

--- a/biosppy/signals/ecg.py
+++ b/biosppy/signals/ecg.py
@@ -20,6 +20,11 @@ import scipy.signal as ss
 from . import tools as st
 from .. import plotting, utils
 
+# Compatible with python 3
+try: 
+    xrange 
+except NameError: 
+    xrange = range
 
 def ecg(signal=None, sampling_rate=1000., show=True):
     """Process a raw ECG signal and extract relevant signal features using

--- a/biosppy/signals/ecg.py
+++ b/biosppy/signals/ecg.py
@@ -117,7 +117,7 @@ def ecg(signal=None, sampling_rate=1000., show=True):
     names = ('ts', 'filtered', 'rpeaks', 'templates_ts', 'templates',
              'heart_rate_ts', 'heart_rate')
 
-    return(ts, filtered, rpeaks, ts_tmpl, templates, ts_hr, hr)
+    return utils.ReturnTuple(args, names)
 
 
 def _extract_heartbeats(signal=None, rpeaks=None, before=200, after=400):
@@ -163,7 +163,7 @@ def _extract_heartbeats(signal=None, rpeaks=None, before=200, after=400):
     templates = np.array(templates)
     newR = np.array(newR, dtype='int')
 
-    return(templates, newR)
+    return templates, newR
 
 
 def extract_heartbeats(signal=None, rpeaks=None, sampling_rate=1000.,
@@ -216,7 +216,7 @@ def extract_heartbeats(signal=None, rpeaks=None, sampling_rate=1000.,
                                           before=before,
                                           after=after)
 
-    return(templates, newR)
+    return utils.ReturnTuple((templates, newR), ('templates', 'rpeaks'))
 
 
 def compare_segmentation(reference=None, test=None, sampling_rate=1000.,
@@ -450,7 +450,7 @@ def ssf_segmenter(signal=None, sampling_rate=1000., threshold=20, before=0.03,
     rpeaks.sort()
     rpeaks = np.array(rpeaks, dtype='int')
 
-    return(rpeaks)
+    return utils.ReturnTuple((rpeaks,), ('rpeaks',))
 
 
 def christov_segmenter(signal=None, sampling_rate=1000.):
@@ -616,7 +616,7 @@ def christov_segmenter(signal=None, sampling_rate=1000.):
     rpeaks = sorted(list(set(rpeaks)))
     rpeaks = np.array(rpeaks, dtype='int')
 
-    return(rpeaks)
+    return utils.ReturnTuple((rpeaks,), ('rpeaks',))
 
 
 def engzee_segmenter(signal=None, sampling_rate=1000., threshold=0.48):
@@ -770,7 +770,7 @@ def engzee_segmenter(signal=None, sampling_rate=1000., threshold=0.48):
     rpeaks = sorted(list(set(rpeaks)))
     rpeaks = np.array(rpeaks, dtype='int')
 
-    return(rpeaks)
+    return utils.ReturnTuple((rpeaks,), ('rpeaks',))
 
 
 def gamboa_segmenter(signal=None, sampling_rate=1000., tol=0.002):
@@ -830,7 +830,7 @@ def gamboa_segmenter(signal=None, sampling_rate=1000., tol=0.002):
 
     rpeaks = np.array(rpeaks, dtype='int')
 
-    return(rpeaks)
+    return utils.ReturnTuple((rpeaks,), ('rpeaks',))
 
 
 def hamilton_segmenter(signal=None, sampling_rate=1000.):
@@ -1136,4 +1136,4 @@ def hamilton_segmenter(signal=None, sampling_rate=1000.):
     rpeaks = sorted(list(set(r_beats)))
     rpeaks = np.array(rpeaks, dtype='int')
 
-    return(rpeaks)
+    return utils.ReturnTuple((rpeaks,), ('rpeaks',))

--- a/biosppy/signals/tools.py
+++ b/biosppy/signals/tools.py
@@ -20,7 +20,25 @@ from scipy.stats import stats
 # local
 from .. import utils
 
-
+# Make it compatible with python
+import types
+try:
+    unicode = unicode
+except NameError:
+    # 'unicode' is undefined, must be Python 3
+    str = str
+    unicode = str
+    bytes = bytes
+    basestring = (str,bytes)
+else:
+    # 'unicode' exists, must be Python 2
+    str = str
+    unicode = unicode
+    bytes = str
+    basestring = basestring
+    
+    
+    
 def _norm_freq(frequency=None, sampling_rate=1000.):
     """Normalize frequency to Nyquist Frequency (Fs/2).
 


### PR DESCRIPTION
Hey, I've come accross your package yesterday. And it seems really awesome. However, it is not compatible with python 3 😢 

I'm pretty sure there are only few changes to make in order to fix it tho.

I did for the ecg function. However, while I applied it successfuly to my data (it got me a nice plot and all), I stumbled accross this weird (no offense 😆) return behavior. Even with your explanation in the docs, I couldn't unpack this return-thing. Why are you not packing the output into a dictionary, where each name is associated with a value that could be anything? It would be simpler and cleaner to get a single dictionary with the different parameters.

Also, I've implemented lazy loading of the signal functions. Since people are not using like 100 times the function `ecg.ecg()`, I think they would like to have the opportunity to keep the full name (i.e. `biosppy.signals.ecg.ecg()`) (altough they still can do the same as before).

Let me know if  you plan to work and maintain this package,

Thanks,
cheers,