### PR TITLE
Feature: added path param to signal processing functions for saving plots

### DIFF
--- a/biosppy/biometrics.py
+++ b/biosppy/biometrics.py
@@ -618,7 +618,7 @@ class BaseClassifier(object):
 
         return subjects
 
-    def evaluate(self, data, thresholds=None, show=False):
+    def evaluate(self, data, thresholds=None, path=None, show=False):
         """Assess the performance of the classifier in both authentication and
         identification scenarios.
 
@@ -628,6 +628,8 @@ class BaseClassifier(object):
             Dictionary holding test data for each subject.
         thresholds : array, optional
             Classifier thresholds to use.
+        path : str, optional
+            If provided, the plot will be saved to the specified file.
         show : bool, optional
             If True, show a summary plot.
 
@@ -693,7 +695,8 @@ class BaseClassifier(object):
 
         if show:
             # plot
-            plotting.plot_biometrics(assess, self.EER_IDX, show=True)
+            plotting.plot_biometrics(
+                assess, self.EER_IDX, path=path, show=True)
 
         return out
 

--- a/biosppy/biometrics.py
+++ b/biosppy/biometrics.py
@@ -695,8 +695,10 @@ class BaseClassifier(object):
 
         if show:
             # plot
-            plotting.plot_biometrics(
-                assess, self.EER_IDX, path=path, show=True)
+            plotting.plot_biometrics(assess,
+                                     self.EER_IDX,
+                                     path=path,
+                                     show=True)
 
         return out
 

--- a/biosppy/signals/bvp.py
+++ b/biosppy/signals/bvp.py
@@ -22,7 +22,7 @@ from . import tools as st
 from .. import plotting, utils
 
 
-def bvp(signal=None, sampling_rate=1000., show=True):
+def bvp(signal=None, sampling_rate=1000., path=None, show=True):
     """Process a raw BVP signal and extract relevant signal features using
     default parameters.
 
@@ -32,6 +32,8 @@ def bvp(signal=None, sampling_rate=1000., show=True):
         Raw BVP signal.
     sampling_rate : int, float, optional
         Sampling frequency (Hz).
+    path : str, optional
+        If provided, the plot will be saved to the specified file.
     show : bool, optional
         If True, show a summary plot.
 
@@ -90,7 +92,7 @@ def bvp(signal=None, sampling_rate=1000., show=True):
                           onsets=onsets,
                           heart_rate_ts=ts_hr,
                           heart_rate=hr,
-                          path=None,
+                          path=path,
                           show=True)
 
     # output

--- a/biosppy/signals/ecg.py
+++ b/biosppy/signals/ecg.py
@@ -25,7 +25,7 @@ from . import tools as st
 from .. import plotting, utils
 
 
-def ecg(signal=None, sampling_rate=1000., show=True):
+def ecg(signal=None, sampling_rate=1000., path=None, show=True):
     """Process a raw ECG signal and extract relevant signal features using
     default parameters.
 
@@ -35,6 +35,8 @@ def ecg(signal=None, sampling_rate=1000., show=True):
         Raw ECG signal.
     sampling_rate : int, float, optional
         Sampling frequency (Hz).
+    path : str, optional
+        If provided, the plot will be saved to the specified file.
     show : bool, optional
         If True, show a summary plot.
 
@@ -114,7 +116,7 @@ def ecg(signal=None, sampling_rate=1000., show=True):
                           templates=templates,
                           heart_rate_ts=ts_hr,
                           heart_rate=hr,
-                          path=None,
+                          path=path,
                           show=True)
 
     # output

--- a/biosppy/signals/eda.py
+++ b/biosppy/signals/eda.py
@@ -23,7 +23,7 @@ from . import tools as st
 from .. import plotting, utils
 
 
-def eda(signal=None, sampling_rate=1000., show=True, min_amplitude=0.1):
+def eda(signal=None, sampling_rate=1000., path=None, show=True, min_amplitude=0.1):
     """Process a raw EDA signal and extract relevant signal features using
     default parameters.
 
@@ -33,6 +33,8 @@ def eda(signal=None, sampling_rate=1000., show=True, min_amplitude=0.1):
         Raw EDA signal.
     sampling_rate : int, float, optional
         Sampling frequency (Hz).
+    path : str, optional
+        If provided, the plot will be saved to the specified file.
     show : bool, optional
         If True, show a summary plot.
     min_amplitude : float, optional
@@ -95,7 +97,7 @@ def eda(signal=None, sampling_rate=1000., show=True, min_amplitude=0.1):
                           onsets=onsets,
                           peaks=peaks,
                           amplitudes=amps,
-                          path=None,
+                          path=path,
                           show=True)
 
     # output

--- a/biosppy/signals/eeg.py
+++ b/biosppy/signals/eeg.py
@@ -23,7 +23,7 @@ from . import tools as st
 from .. import plotting, utils
 
 
-def eeg(signal=None, sampling_rate=1000., labels=None, show=True):
+def eeg(signal=None, sampling_rate=1000., labels=None, path=None, show=True):
     """Process raw EEG signals and extract relevant signal features using
     default parameters.
 
@@ -35,6 +35,8 @@ def eeg(signal=None, sampling_rate=1000., labels=None, show=True):
         Sampling frequency (Hz).
     labels : list, optional
         Channel labels.
+    path : str, optional
+        If provided, the plot will be saved to the specified file.
     show : bool, optional
         If True, show a summary plot.
 
@@ -140,7 +142,7 @@ def eeg(signal=None, sampling_rate=1000., labels=None, show=True):
                           gamma=gamma,
                           plf_pairs=plf_pairs,
                           plf=plf,
-                          path=None,
+                          path=path,
                           show=True)
 
     # output

--- a/biosppy/signals/emg.py
+++ b/biosppy/signals/emg.py
@@ -21,7 +21,7 @@ from . import tools as st
 from .. import plotting, utils
 
 
-def emg(signal=None, sampling_rate=1000., show=True):
+def emg(signal=None, sampling_rate=1000., path=None, show=True):
     """Process a raw EMG signal and extract relevant signal features using
     default parameters.
 
@@ -31,6 +31,8 @@ def emg(signal=None, sampling_rate=1000., show=True):
         Raw EMG signal.
     sampling_rate : int, float, optional
         Sampling frequency (Hz).
+    path : str, optional
+        If provided, the plot will be saved to the specified file.
     show : bool, optional
         If True, show a summary plot.
 
@@ -78,7 +80,7 @@ def emg(signal=None, sampling_rate=1000., show=True):
                           filtered=filtered,
                           processed=None,
                           onsets=onsets,
-                          path=None,
+                          path=path,
                           show=True)
 
     # output

--- a/biosppy/signals/resp.py
+++ b/biosppy/signals/resp.py
@@ -21,7 +21,7 @@ from . import tools as st
 from .. import plotting, utils
 
 
-def resp(signal=None, sampling_rate=1000., show=True):
+def resp(signal=None, sampling_rate=1000., path=None, show=True):
     """Process a raw Respiration signal and extract relevant signal features
     using default parameters.
 
@@ -31,6 +31,8 @@ def resp(signal=None, sampling_rate=1000., show=True):
         Raw Respiration signal.
     sampling_rate : int, float, optional
         Sampling frequency (Hz).
+    path : str, optional
+        If provided, the plot will be saved to the specified file.
     show : bool, optional
         If True, show a summary plot.
 
@@ -104,7 +106,7 @@ def resp(signal=None, sampling_rate=1000., show=True):
                            zeros=zeros,
                            resp_rate_ts=ts_rate,
                            resp_rate=rate,
-                           path=None,
+                           path=path,
                            show=True)
 
     # output


### PR DESCRIPTION
The `plotting.py` module supports saving to a file if the `path` param is provided. However, all the summary processing and plotting functions like `signals.ecg.ecg` hardcode the path to be `None`. Saving plots like this to a file is useful for users that want to automate and process a large amount of signals. This PR propagates the path param to the functions that offer plotting in addition to processing.