### PR TITLE
Removed sklearn joblib deprecation warning

### DIFF
--- a/biosppy/storage.py
+++ b/biosppy/storage.py
@@ -25,7 +25,7 @@ import zipfile
 import h5py
 import numpy as np
 import shortuuid
-from sklearn.externals import joblib
+import joblib
 
 # local
 from . import utils


### PR DESCRIPTION
Removed sklearn joblib deprecation warning by importing joblib directly in storage.py rather than from sklearn