### PR TITLE
Removed deprecation warning from sklearn, by importing joblib independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This should produce a plot similar to the one below.
 - scipy
 - shortuuid
 - six
+- joblib
 
 ## Citing
 Please use the following if you need to cite BioSPPy:

--- a/biosppy/storage.py
+++ b/biosppy/storage.py
@@ -25,7 +25,7 @@ import zipfile
 import h5py
 import numpy as np
 import shortuuid
-from sklearn.externals import joblib
+import joblib
 
 # local
 from . import utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scikit-learn==0.19.1
 scipy==1.0.0
 shortuuid==0.5.0
 six==1.11.0
+joblin==0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ scikit-learn==0.19.1
 scipy==1.0.0
 shortuuid==0.5.0
 six==1.11.0
-joblin==0.11
+joblib==0.11

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ REQUIRED = [
     'scipy',
     'shortuuid',
     'six',
+    'joblib'
 ]
 
 # What packages are optional?


### PR DESCRIPTION
Removed the deprecation warning shown by current sklearn version, by importing joblib independently in biosppy/storage.py rather than from sklearn.externals.
Added joblib as a requirement in setup.py, requirements.txt and README.md