### PR TITLE
Fix onset calculation for BVP module

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ methods geared towards the analysis of biosignals.
 
 Highlights:
 
-- Support for various biosignals: BVP, ECG, EDA, EEG, EMG, Respiration
+- Support for various biosignals: PPG, ECG, EDA, EEG, EMG, Respiration
 - Signal analysis primitives: filtering, frequency analysis
 - Clustering
 - Biometrics

--- a/biosppy/__init__.py
+++ b/biosppy/__init__.py
@@ -16,4 +16,4 @@ from __future__ import absolute_import, division, print_function
 from .__version__ import __version__
 
 # allow lazy loading
-from .signals import bvp, ecg, eda, eeg, emg, resp, tools
+from .signals import abp, bvp, ppg, ecg, eda, eeg, emg, resp, tools

--- a/biosppy/plotting.py
+++ b/biosppy/plotting.py
@@ -209,6 +209,99 @@ def plot_spectrum(signal=None, sampling_rate=1000., path=None, show=True):
         plt.close(fig)
 
 
+def plot_ppg(ts=None,
+             raw=None,
+             filtered=None,
+             onsets=None,
+             heart_rate_ts=None,
+             heart_rate=None,
+             path=None,
+             show=False):
+    """Create a summary plot from the output of signals.ppg.ppg.
+
+    Parameters
+    ----------
+    ts : array
+        Signal time axis reference (seconds).
+    raw : array
+        Raw PPG signal.
+    filtered : array
+        Filtered PPG signal.
+    onsets : array
+        Indices of PPG pulse onsets.
+    heart_rate_ts : array
+        Heart rate time axis reference (seconds).
+    heart_rate : array
+        Instantaneous heart rate (bpm).
+    path : str, optional
+        If provided, the plot will be saved to the specified file.
+    show : bool, optional
+        If True, show the plot immediately.
+
+    """
+
+    fig = plt.figure()
+    fig.suptitle('PPG Summary')
+
+    # raw signal
+    ax1 = fig.add_subplot(311)
+
+    ax1.plot(ts, raw, linewidth=MAJOR_LW, label='Raw')
+
+    ax1.set_ylabel('Amplitude')
+    ax1.legend()
+    ax1.grid()
+
+    # filtered signal with onsets
+    ax2 = fig.add_subplot(312, sharex=ax1)
+
+    ymin = np.min(filtered)
+    ymax = np.max(filtered)
+    alpha = 0.1 * (ymax - ymin)
+    ymax += alpha
+    ymin -= alpha
+
+    ax2.plot(ts, filtered, linewidth=MAJOR_LW, label='Filtered')
+    ax2.vlines(ts[onsets], ymin, ymax,
+               color='m',
+               linewidth=MINOR_LW,
+               label='Onsets')
+
+    ax2.set_ylabel('Amplitude')
+    ax2.legend()
+    ax2.grid()
+
+    # heart rate
+    ax3 = fig.add_subplot(313, sharex=ax1)
+
+    ax3.plot(heart_rate_ts, heart_rate, linewidth=MAJOR_LW, label='Heart Rate')
+
+    ax3.set_xlabel('Time (s)')
+    ax3.set_ylabel('Heart Rate (bpm)')
+    ax3.legend()
+    ax3.grid()
+
+    # make layout tight
+    fig.tight_layout()
+
+    # save to file
+    if path is not None:
+        path = utils.normpath(path)
+        root, ext = os.path.splitext(path)
+        ext = ext.lower()
+        if ext not in ['png', 'jpg']:
+            path = root + '.png'
+
+        fig.savefig(path, dpi=200, bbox_inches='tight')
+
+    # show
+    if show:
+        plt.show()
+    else:
+        # close
+        plt.close(fig)
+
+
 def plot_bvp(ts=None,
              raw=None,
              filtered=None,
@@ -301,6 +394,98 @@ def plot_bvp(ts=None,
         # close
         plt.close(fig)
 
+
+def plot_abp(ts=None,
+             raw=None,
+             filtered=None,
+             onsets=None,
+             heart_rate_ts=None,
+             heart_rate=None,
+             path=None,
+             show=False):
+    """Create a summary plot from the output of signals.abp.abp.
+
+    Parameters
+    ----------
+    ts : array
+        Signal time axis reference (seconds).
+    raw : array
+        Raw ABP signal.
+    filtered : array
+        Filtered ABP signal.
+    onsets : array
+        Indices of ABP pulse onsets.
+    heart_rate_ts : array
+        Heart rate time axis reference (seconds).
+    heart_rate : array
+        Instantaneous heart rate (bpm).
+    path : str, optional
+        If provided, the plot will be saved to the specified file.
+    show : bool, optional
+        If True, show the plot immediately.
+
+    """
+
+    fig = plt.figure()
+    fig.suptitle('ABP Summary')
+
+    # raw signal
+    ax1 = fig.add_subplot(311)
+
+    ax1.plot(ts, raw, linewidth=MAJOR_LW, label='Raw')
+
+    ax1.set_ylabel('Amplitude')
+    ax1.legend()
+    ax1.grid()
+
+    # filtered signal with onsets
+    ax2 = fig.add_subplot(312, sharex=ax1)
+
+    ymin = np.min(filtered)
+    ymax = np.max(filtered)
+    alpha = 0.1 * (ymax - ymin)
+    ymax += alpha
+    ymin -= alpha
+
+    ax2.plot(ts, filtered, linewidth=MAJOR_LW, label='Filtered')
+    ax2.vlines(ts[onsets], ymin, ymax,
+               color='m',
+               linewidth=MINOR_LW,
+               label='Onsets')
+
+    ax2.set_ylabel('Amplitude')
+    ax2.legend()
+    ax2.grid()
+
+    # heart rate
+    ax3 = fig.add_subplot(313, sharex=ax1)
+
+    ax3.plot(heart_rate_ts, heart_rate, linewidth=MAJOR_LW, label='Heart Rate')
+
+    ax3.set_xlabel('Time (s)')
+    ax3.set_ylabel('Heart Rate (bpm)')
+    ax3.legend()
+    ax3.grid()
+
+    # make layout tight
+    fig.tight_layout()
+
+    # save to file
+    if path is not None:
+        path = utils.normpath(path)
+        root, ext = os.path.splitext(path)
+        ext = ext.lower()
+        if ext not in ['png', 'jpg']:
+            path = root + '.png'
+
+        fig.savefig(path, dpi=200, bbox_inches='tight')
+
+    # show
+    if show:
+        plt.show()
+    else:
+        # close
+        plt.close(fig)
 
 def plot_eda(ts=None,
              raw=None,
@@ -507,7 +692,7 @@ def plot_resp(ts=None,
               resp_rate=None,
               path=None,
               show=False):
-    """Create a summary plot from the output of signals.bvp.bvp.
+    """Create a summary plot from the output of signals.ppg.ppg.
 
     Parameters
     ----------

--- a/biosppy/signals/__init__.py
+++ b/biosppy/signals/__init__.py
@@ -5,7 +5,7 @@ biosppy.signals
 
 This package provides methods to process common
 physiological signals (biosignals):
-    * Blood Volume Pulse (BVP)
+    * Photoplethysmogram (PPG)
     * Electrocardiogram (ECG)
     * Electrodermal Activity (EDA)
     * Electroencephalogram (EEG)
@@ -20,4 +20,4 @@ physiological signals (biosignals):
 from __future__ import absolute_import, division, print_function
 
 # allow lazy loading
-from . import bvp, ecg, eda, eeg, emg, resp, tools
+from . import abp, bvp, ppg, ecg, eda, eeg, emg, resp, tools

--- a/biosppy/signals/abp.py
+++ b/biosppy/signals/abp.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+"""
+biosppy.signals.abp
+-------------------
+
+This module provides methods to process Arterial Blood Pressure (ABP) signals.
+
+
+:copyright: (c) 2015-2018 by Instituto de Telecomunicacoes
+:license: BSD 3-clause, see LICENSE for more details.
+"""
+
+# Imports
+# compat
+from __future__ import absolute_import, division, print_function
+from six.moves import range
+
+# 3rd party
+import numpy as np
+
+# local
+from . import tools as st
+from .. import plotting, utils
+
+
+def abp(signal=None, sampling_rate=1000., show=True):
+    """Process a raw ABP signal and extract relevant signal features using
+    default parameters.
+
+    Parameters
+    ----------
+    signal : array
+        Raw ABP signal.
+    sampling_rate : int, float, optional
+        Sampling frequency (Hz).
+    show : bool, optional
+        If True, show a summary plot.
+
+    Returns
+    -------
+    ts : array
+        Signal time axis reference (seconds).
+    filtered : array
+        Filtered ABP signal.
+    onsets : array
+        Indices of ABP pulse onsets.
+    heart_rate_ts : array
+        Heart rate time axis reference (seconds).
+    heart_rate : array
+        Instantaneous heart rate (bpm).
+
+    """
+
+    # check inputs
+    if signal is None:
+        raise TypeError("Please specify an input signal.")
+
+    # ensure numpy
+    signal = np.array(signal)
+
+    sampling_rate = float(sampling_rate)
+
+    # filter signal
+    filtered, _, _ = st.filter_signal(signal=signal,
+                                      ftype='butter',
+                                      band='bandpass',
+                                      order=4,
+                                      frequency=[1, 8],
+                                      sampling_rate=sampling_rate)
+
+    # find onsets
+    onsets, _ = find_onsets_elgendi2013(signal=filtered, sampling_rate=sampling_rate)
+
+    # compute heart rate
+    hr_idx, hr = st.get_heart_rate(beats=onsets,
+                                   sampling_rate=sampling_rate,
+                                   smooth=True,
+                                   size=3)
+
+    # get time vectors
+    length = len(signal)
+    T = (length - 1) / sampling_rate
+    ts = np.linspace(0, T, length, endpoint=False)
+    ts_hr = ts[hr_idx]
+
+    # plot
+    if show:
+        plotting.plot_abp(ts=ts,
+                          raw=signal,
+                          filtered=filtered,
+                          onsets=onsets,
+                          heart_rate_ts=ts_hr,
+                          heart_rate=hr,
+                          path=None,
+                          show=True)
+
+    # output
+    args = (ts, filtered, onsets, ts_hr, hr)
+    names = ('ts', 'filtered', 'onsets', 'heart_rate_ts', 'heart_rate')
+
+    return utils.ReturnTuple(args, names)
+
+
+def find_onsets_zong03(signal=None, sampling_rate=1000., sm_size=None, size=None,
+                alpha=2., wrange=None, d1_th=0, d2_th=None):
+    """Determine onsets of ABP pulses.
+    Skips corrupted signal parts.
+    Based on the approach by Zong *et al.* [Zong03]_.
+    Parameters
+    ----------
+    signal : array
+        Input filtered ABP signal.
+    sampling_rate : int, float, optional
+        Sampling frequency (Hz).
+    sm_size : int, optional
+        Size of smoother kernel (seconds).
+        Defaults to 0.25
+    size : int, optional
+        Window to search for maxima (seconds).
+        Defaults to 5
+    alpha : float, optional
+        Normalization parameter.
+        Defaults to 2.0
+    wrange : int, optional
+        The window in which to search for a peak (seconds).
+        Defaults to 0.1
+    d1_th : int, optional
+        Smallest allowed difference between maxima and minima.
+        Defaults to 0
+    d2_th : int, optional
+        Smallest allowed time between maxima and minima (seconds),
+        Defaults to 0.15
+    Returns
+    -------
+    onsets : array
+        Indices of ABP pulse onsets.
+    
+    References
+    ----------
+    .. [Zong03] W Zong, T Heldt, GB Moody and RG Mark, "An Open-source
+       Algorithm to Detect Onset of Arterial Blood Pressure Pulses",
+       IEEE Comp. in Cardiology, vol. 30, pp. 259-262, 2003
+    """
+
+    # check inputs
+    if signal is None:
+        raise TypeError("Please specify an input signal.")
+
+    # parameters
+    sm_size = 0.25 if not sm_size else sm_size
+    sm_size = int(sm_size * sampling_rate)
+    size = 5 if not size else size
+    size = int(size * sampling_rate)
+    wrange = 0.1 if not wrange else wrange
+    wrange = int(wrange * sampling_rate)
+    d2_th = 0.15 if not d2_th else d2_th
+    d2_th = int(d2_th * sampling_rate)
+
+    length = len(signal)
+
+    # slope sum function
+    dy = np.diff(signal)
+    dy[dy < 0] = 0
+
+    ssf, _ = st.smoother(signal=dy, kernel='boxcar', size=sm_size, mirror=True)
+
+    # main loop
+    start = 0
+    stop = size
+    if stop > length:
+        stop = length
+
+    idx = []
+
+    while True:
+        sq = np.copy(signal[start:stop])
+        sq -= sq.mean()
+        # sq = sq[1:]
+        ss = 25 * ssf[start:stop]
+        sss = 100 * np.diff(ss)
+        sss[sss < 0] = 0
+        sss = sss - alpha * np.mean(sss)
+
+        # find maxima
+        pk, pv = st.find_extrema(signal=sss, mode='max')
+        pk = pk[np.nonzero(pv > 0)]
+        pk += wrange
+        dpidx = pk
+
+        # analyze between maxima of 2nd derivative of ss
+        detected = False
+        for i in range(1, len(dpidx) + 1):
+            try:
+                v, u = dpidx[i - 1], dpidx[i]
+            except IndexError:
+                v, u = dpidx[-1], -1
+
+            s = sq[v:u]
+            Mk, Mv = st.find_extrema(signal=s, mode='max')
+            mk, mv = st.find_extrema(signal=s, mode='min')
+
+            try:
+                M = Mk[np.argmax(Mv)]
+                m = mk[np.argmax(mv)]
+            except ValueError:
+                continue
+
+            if (s[M] - s[m] > d1_th) and (m - M > d2_th):
+                idx += [v + start]
+                detected = True
+
+        # next round continues from previous detected beat
+        if detected:
+            start = idx[-1] + wrange
+        else:
+            start += size
+
+        # stop condition
+        if start > length:
+            break
+
+        # update stop
+        stop += size
+        if stop > length:
+            stop = length
+
+    idx = np.array(idx, dtype='int')
+
+    return utils.ReturnTuple((idx,), ('onsets',))

--- a/biosppy/signals/abp.py
+++ b/biosppy/signals/abp.py
@@ -69,7 +69,7 @@ def abp(signal=None, sampling_rate=1000., show=True):
                                       sampling_rate=sampling_rate)
 
     # find onsets
-    onsets, _ = find_onsets_elgendi2013(signal=filtered, sampling_rate=sampling_rate)
+    onsets, _ = find_onsets_zong2003(signal=filtered, sampling_rate=sampling_rate)
 
     # compute heart rate
     hr_idx, hr = st.get_heart_rate(beats=onsets,
@@ -101,7 +101,7 @@ def abp(signal=None, sampling_rate=1000., show=True):
     return utils.ReturnTuple(args, names)
 
 
-def find_onsets_zong03(signal=None, sampling_rate=1000., sm_size=None, size=None,
+def find_onsets_zong2003(signal=None, sampling_rate=1000., sm_size=None, size=None,
                 alpha=2., wrange=None, d1_th=0, d2_th=None):
     """Determine onsets of ABP pulses.
     Skips corrupted signal parts.

--- a/biosppy/signals/bvp.py
+++ b/biosppy/signals/bvp.py
@@ -5,6 +5,11 @@ biosppy.signals.bvp
 
 This module provides methods to process Blood Volume Pulse (BVP) signals.
 
+-------- DEPRECATED --------
+PLEASE, USE THE PPG MODULE
+This module was left for compatibility
+----------------------------
+
 :copyright: (c) 2015-2018 by Instituto de Telecomunicacoes
 :license: BSD 3-clause, see LICENSE for more details.
 """
@@ -16,17 +21,16 @@ from six.moves import range
 
 # 3rd party
 import numpy as np
-import scipy
 
 # local
 from . import tools as st
+from . import ppg
 from .. import plotting, utils
 
 
 def bvp(signal=None, sampling_rate=1000., show=True):
     """Process a raw BVP signal and extract relevant signal features using
     default parameters.
-
     Parameters
     ----------
     signal : array
@@ -35,7 +39,6 @@ def bvp(signal=None, sampling_rate=1000., show=True):
         Sampling frequency (Hz).
     show : bool, optional
         If True, show a summary plot.
-
     Returns
     -------
     ts : array
@@ -48,7 +51,6 @@ def bvp(signal=None, sampling_rate=1000., show=True):
         Heart rate time axis reference (seconds).
     heart_rate : array
         Instantaneous heart rate (bpm).
-
     """
 
     # check inputs
@@ -69,8 +71,7 @@ def bvp(signal=None, sampling_rate=1000., show=True):
                                       sampling_rate=sampling_rate)
 
     # find onsets
-    # onsets, = find_onsets(signal=filtered, sampling_rate=sampling_rate)
-    onsets, _ = find_onsets_elgendi2013(signal=filtered, sampling_rate=sampling_rate)
+    onsets, = ppg.find_onsets_elgendi2013(signal=filtered, sampling_rate=sampling_rate)
 
     # compute heart rate
     hr_idx, hr = st.get_heart_rate(beats=onsets,
@@ -101,265 +102,4 @@ def bvp(signal=None, sampling_rate=1000., show=True):
 
     return utils.ReturnTuple(args, names)
 
-def find_onsets_elgendi2013(signal=None, sampling_rate=1000., peakwindow=0.111, beatwindow=0.667, beatoffset=0.02, mindelay=0.3):
-    """
-    Determines onsets of BVP pulses.
 
-    Parameters
-    ----------
-    signal : array
-        Input filtered BVP signal.
-    sampling_rate : int, float, optional
-        Sampling frequency (Hz).
-    peakwindow : float
-        Parameter W1 on referenced article
-        Optimized at 0.111
-    beatwindow : float
-        Parameter W2 on referenced article
-        Optimized at 0.667
-    beatoffset : float
-        Parameter beta on referenced article
-        Optimized at 0.2
-    mindelay : float
-        Minimum delay between peaks.
-        Avoids false positives
-
-    Returns
-    ----------
-    onsets : array
-        Indices of BVP pulse onsets.
-    params : dict
-        Input parameters of the function
-
-
-    References
-    ----------
-    - Elgendi M, Norton I, Brearley M, Abbott D, Schuurmans D (2013) Systolic Peak Detection in
-    Acceleration Photoplethysmograms Measured from Emergency Responders in Tropical Conditions.
-    PLoS ONE 8(10): e76585. doi:10.1371/journal.pone.0076585.
-    
-    Notes
-    ---------------------
-    Optimal ranges for signal filtering (from Elgendi et al. 2013):
-    "Optimization of the beat detector’s spectral window for the lower frequency resulted in a 
-    value within 0.5– 1 Hz with the higher frequency within 7–15 Hz"
-    
-    All the number references below between curly brackets {...} by the code refer to the line numbers of
-    code in "Table 2 Algorithm IV: DETECTOR (PPG signal, F1, F2, W1, W2, b)" from Elgendi et al. 2013 for a
-    better comparison of the algorithm
-    
-    """
-
-    # check inputs
-    if signal is None:
-        raise TypeError("Please specify an input signal.")
-
-    # Create copy of signal (not to modify the original object)
-    signal_copy = np.copy(signal)
-
-    # Truncate to zero and square
-    # {3, 4}
-    signal_copy[signal_copy < 0] = 0
-    squared_signal = signal_copy ** 2
-
-    # Calculate peak detection threshold
-    # {5}
-    ma_peak_kernel = int(np.rint(peakwindow * sampling_rate))
-    ma_peak, _ = st.smoother(squared_signal, kernel="boxcar", size=ma_peak_kernel)
-
-    # {6}
-    ma_beat_kernel = int(np.rint(beatwindow * sampling_rate))
-    ma_beat, _ = st.smoother(squared_signal, kernel="boxcar", size=ma_beat_kernel)
-
-    # Calculate threshold value
-    # {7, 8, 9}
-    thr1 = ma_beat + beatoffset * np.mean(squared_signal)
-
-    # Identify start and end of BVP waves.
-    # {10-16}
-    waves = ma_peak > thr1
-    beg_waves = np.where(np.logical_and(np.logical_not(waves[0:-1]), waves[1:]))[0]
-    end_waves = np.where(np.logical_and(waves[0:-1], np.logical_not(waves[1:])))[0]
-    # Throw out wave-ends that precede first wave-start.
-    end_waves = end_waves[end_waves > beg_waves[0]]
-
-    # Identify systolic peaks within waves (ignore waves that are too short).
-    num_waves = min(beg_waves.size, end_waves.size)
-    # {18}
-    min_len = int(np.rint(peakwindow * sampling_rate))
-    min_delay = int(np.rint(mindelay * sampling_rate))
-    onsets = [0]
-
-    # {19}
-    for i in range(num_waves):
-
-        beg = beg_waves[i]
-        end = end_waves[i]
-        len_wave = end - beg
-
-        # {20, 22, 23}
-        if len_wave < min_len:
-            continue
-
-        # Find local maxima and their prominence within wave span.
-        # {21}
-        data = signal_copy[beg:end]
-        locmax, props = scipy.signal.find_peaks(data, prominence=(None, None))
-
-        # If more than one peak
-        if locmax.size > 0:
-            # Identify most prominent local maximum.
-            peak = beg + locmax[np.argmax(props["prominences"])]
-            # Enforce minimum delay between onsets.
-            if peak - onsets[-1] > min_delay:
-                onsets.append(peak)
-
-    onsets.pop(0)
-    onsets = np.array(onsets, dtype='int')
-
-    # output
-    params = {'signal': signal, 'sampling_rate': sampling_rate, 'peakwindow': peakwindow, 'beatwindow': beatwindow, 'beatoffset': beatoffset, 'mindelay': mindelay}
-
-    args = (onsets, params)
-    names = ('onsets', 'params')
-
-    return utils.ReturnTuple(args, names)
-
-
-
-def find_onsets_zong03(signal=None, sampling_rate=1000., sm_size=None, size=None,
-                alpha=2., wrange=None, d1_th=0, d2_th=None):
-
-    """
-
-    DEPRECATED METHOD
-
-
-    Determine onsets of BVP pulses.
-
-    Skips corrupted signal parts.
-    Based on the approach by Zong *et al.* [Zong03]_.
-
-    Parameters
-    ----------
-    signal : array
-        Input filtered BVP signal.
-    sampling_rate : int, float, optional
-        Sampling frequency (Hz).
-    sm_size : int, optional
-        Size of smoother kernel (seconds).
-        Defaults to 0.25
-    size : int, optional
-        Window to search for maxima (seconds).
-        Defaults to 5
-    alpha : float, optional
-        Normalization parameter.
-        Defaults to 2.0
-    wrange : int, optional
-        The window in which to search for a peak (seconds).
-        Defaults to 0.1
-    d1_th : int, optional
-        Smallest allowed difference between maxima and minima.
-        Defaults to 0
-    d2_th : int, optional
-        Smallest allowed time between maxima and minima (seconds),
-        Defaults to 0.15
-
-    Returns
-    -------
-    onsets : array
-        Indices of BVP pulse onsets.
-    
-    References
-    ----------
-    .. [Zong03] W Zong, T Heldt, GB Moody and RG Mark, "An Open-source
-       Algorithm to Detect Onset of Arterial Blood Pressure Pulses",
-       IEEE Comp. in Cardiology, vol. 30, pp. 259-262, 2003
-
-    """
-
-    # check inputs
-    if signal is None:
-        raise TypeError("Please specify an input signal.")
-
-    # parameters
-    sm_size = 0.25 if not sm_size else sm_size
-    sm_size = int(sm_size * sampling_rate)
-    size = 5 if not size else size
-    size = int(size * sampling_rate)
-    wrange = 0.1 if not wrange else wrange
-    wrange = int(wrange * sampling_rate)
-    d2_th = 0.15 if not d2_th else d2_th
-    d2_th = int(d2_th * sampling_rate)
-
-    length = len(signal)
-
-    # slope sum function
-    dy = np.diff(signal)
-    dy[dy < 0] = 0
-
-    ssf, _ = st.smoother(signal=dy, kernel='boxcar', size=sm_size, mirror=True)
-
-    # main loop
-    start = 0
-    stop = size
-    if stop > length:
-        stop = length
-
-    idx = []
-
-    while True:
-        sq = np.copy(signal[start:stop])
-        sq -= sq.mean()
-        # sq = sq[1:]
-        ss = 25 * ssf[start:stop]
-        sss = 100 * np.diff(ss)
-        sss[sss < 0] = 0
-        sss = sss - alpha * np.mean(sss)
-
-        # find maxima
-        pk, pv = st.find_extrema(signal=sss, mode='max')
-        pk = pk[np.nonzero(pv > 0)]
-        pk += wrange
-        dpidx = pk
-
-        # analyze between maxima of 2nd derivative of ss
-        detected = False
-        for i in range(1, len(dpidx) + 1):
-            try:
-                v, u = dpidx[i - 1], dpidx[i]
-            except IndexError:
-                v, u = dpidx[-1], -1
-
-            s = sq[v:u]
-            Mk, Mv = st.find_extrema(signal=s, mode='max')
-            mk, mv = st.find_extrema(signal=s, mode='min')
-
-            try:
-                M = Mk[np.argmax(Mv)]
-                m = mk[np.argmax(mv)]
-            except ValueError:
-                continue
-
-            if (s[M] - s[m] > d1_th) and (m - M > d2_th):
-                idx += [v + start]
-                detected = True
-
-        # next round continues from previous detected beat
-        if detected:
-            start = idx[-1] + wrange
-        else:
-            start += size
-
-        # stop condition
-        if start > length:
-            break
-
-        # update stop
-        stop += size
-        if stop > length:
-            stop = length
-
-    idx = np.array(idx, dtype='int')
-
-    return utils.ReturnTuple((idx,), ('onsets',))

--- a/biosppy/signals/bvp.py
+++ b/biosppy/signals/bvp.py
@@ -16,6 +16,7 @@ from six.moves import range
 
 # 3rd party
 import numpy as np
+import scipy
 
 # local
 from . import tools as st

--- a/biosppy/signals/bvp.py
+++ b/biosppy/signals/bvp.py
@@ -68,7 +68,8 @@ def bvp(signal=None, sampling_rate=1000., show=True):
                                       sampling_rate=sampling_rate)
 
     # find onsets
-    onsets, = find_onsets(signal=filtered, sampling_rate=sampling_rate)
+    # onsets, = find_onsets(signal=filtered, sampling_rate=sampling_rate)
+    onsets, _ = find_onsets_elgendi2013(signal=filtered, sampling_rate=sampling_rate)
 
     # compute heart rate
     hr_idx, hr = st.get_heart_rate(beats=onsets,
@@ -99,10 +100,141 @@ def bvp(signal=None, sampling_rate=1000., show=True):
 
     return utils.ReturnTuple(args, names)
 
+def find_onsets_elgendi2013(signal=None, sampling_rate=1000., peakwindow=0.111, beatwindow=0.667, beatoffset=0.02, mindelay=0.3):
+    """
+    Determines onsets of BVP pulses.
 
-def find_onsets(signal=None, sampling_rate=1000., sm_size=None, size=None,
+    Parameters
+    ----------
+    signal : array
+        Input filtered BVP signal.
+    sampling_rate : int, float, optional
+        Sampling frequency (Hz).
+    peakwindow : float
+        Parameter W1 on referenced article
+        Optimized at 0.111
+    beatwindow : float
+        Parameter W2 on referenced article
+        Optimized at 0.667
+    beatoffset : float
+        Parameter beta on referenced article
+        Optimized at 0.2
+    mindelay : float
+        Minimum delay between peaks.
+        Avoids false positives
+
+    Returns
+    ----------
+    onsets : array
+        Indices of BVP pulse onsets.
+    params : dict
+        Input parameters of the function
+
+
+    References
+    ----------
+    - Elgendi M, Norton I, Brearley M, Abbott D, Schuurmans D (2013) Systolic Peak Detection in
+    Acceleration Photoplethysmograms Measured from Emergency Responders in Tropical Conditions.
+    PLoS ONE 8(10): e76585. doi:10.1371/journal.pone.0076585.
+    
+    Notes
+    ---------------------
+    Optimal ranges for signal filtering (from Elgendi et al. 2013):
+    "Optimization of the beat detector’s spectral window for the lower frequency resulted in a 
+    value within 0.5– 1 Hz with the higher frequency within 7–15 Hz"
+    
+    All the number references below between curly brackets {...} by the code refer to the line numbers of
+    code in "Table 2 Algorithm IV: DETECTOR (PPG signal, F1, F2, W1, W2, b)" from Elgendi et al. 2013 for a
+    better comparison of the algorithm
+    
+    """
+
+    # check inputs
+    if signal is None:
+        raise TypeError("Please specify an input signal.")
+
+    # Create copy of signal (not to modify the original object)
+    signal_copy = np.copy(signal)
+
+    # Truncate to zero and square
+    # {3, 4}
+    signal_copy[signal_copy < 0] = 0
+    squared_signal = signal_copy ** 2
+
+    # Calculate peak detection threshold
+    # {5}
+    ma_peak_kernel = int(np.rint(peakwindow * sampling_rate))
+    ma_peak, _ = st.smoother(squared_signal, kernel="boxcar", size=ma_peak_kernel)
+
+    # {6}
+    ma_beat_kernel = int(np.rint(beatwindow * sampling_rate))
+    ma_beat, _ = st.smoother(squared_signal, kernel="boxcar", size=ma_beat_kernel)
+
+    # Calculate threshold value
+    # {7, 8, 9}
+    thr1 = ma_beat + beatoffset * np.mean(squared_signal)
+
+    # Identify start and end of BVP waves.
+    # {10-16}
+    waves = ma_peak > thr1
+    beg_waves = np.where(np.logical_and(np.logical_not(waves[0:-1]), waves[1:]))[0]
+    end_waves = np.where(np.logical_and(waves[0:-1], np.logical_not(waves[1:])))[0]
+    # Throw out wave-ends that precede first wave-start.
+    end_waves = end_waves[end_waves > beg_waves[0]]
+
+    # Identify systolic peaks within waves (ignore waves that are too short).
+    num_waves = min(beg_waves.size, end_waves.size)
+    # {18}
+    min_len = int(np.rint(peakwindow * sampling_rate))
+    min_delay = int(np.rint(mindelay * sampling_rate))
+    onsets = [0]
+
+    # {19}
+    for i in range(num_waves):
+
+        beg = beg_waves[i]
+        end = end_waves[i]
+        len_wave = end - beg
+
+        # {20, 22, 23}
+        if len_wave < min_len:
+            continue
+
+        # Find local maxima and their prominence within wave span.
+        # {21}
+        data = signal_copy[beg:end]
+        locmax, props = scipy.signal.find_peaks(data, prominence=(None, None))
+
+        # If more than one peak
+        if locmax.size > 0:
+            # Identify most prominent local maximum.
+            peak = beg + locmax[np.argmax(props["prominences"])]
+            # Enforce minimum delay between onsets.
+            if peak - onsets[-1] > min_delay:
+                onsets.append(peak)
+
+    onsets.pop(0)
+    onsets = np.array(onsets, dtype='int')
+
+    # output
+    params = {'signal': signal, 'sampling_rate': sampling_rate, 'peakwindow': peakwindow, 'beatwindow': beatwindow, 'beatoffset': beatoffset, 'mindelay': mindelay}
+
+    args = (onsets, params)
+    names = ('onsets', 'params')
+
+    return utils.ReturnTuple(args, names)
+
+
+
+def find_onsets_zong03(signal=None, sampling_rate=1000., sm_size=None, size=None,
                 alpha=2., wrange=None, d1_th=0, d2_th=None):
-    """Determine onsets of BVP pulses.
+
+    """
+
+    DEPRECATED METHOD
+
+
+    Determine onsets of BVP pulses.
 
     Skips corrupted signal parts.
     Based on the approach by Zong *et al.* [Zong03]_.

--- a/biosppy/signals/eeg.py
+++ b/biosppy/signals/eeg.py
@@ -43,7 +43,7 @@ def eeg(signal=None, sampling_rate=1000., labels=None, show=True):
     ts : array
         Signal time axis reference (seconds).
     filtered : array
-        Filtered BVP signal.
+        Filtered PPG signal.
     features_ts : array
         Features time axis reference (seconds).
     theta : array

--- a/biosppy/signals/eeg.py
+++ b/biosppy/signals/eeg.py
@@ -43,7 +43,7 @@ def eeg(signal=None, sampling_rate=1000., labels=None, show=True):
     ts : array
         Signal time axis reference (seconds).
     filtered : array
-        Filtered PPG signal.
+        Filtered EEG signal.
     features_ts : array
         Features time axis reference (seconds).
     theta : array

--- a/biosppy/signals/ppg.py
+++ b/biosppy/signals/ppg.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+"""
+biosppy.signals.ppg
+-------------------
+
+This module provides methods to process Photoplethysmogram (PPG) signals.
+
+:copyright: (c) 2015-2018 by Instituto de Telecomunicacoes
+:license: BSD 3-clause, see LICENSE for more details.
+"""
+
+# Imports
+# compat
+from __future__ import absolute_import, division, print_function
+from six.moves import range
+
+# 3rd party
+import numpy as np
+import scipy.signal as ss
+
+# local
+from . import tools as st
+from .. import plotting, utils
+
+
+def ppg(signal=None, sampling_rate=1000., show=True):
+    """Process a raw PPG signal and extract relevant signal features using
+    default parameters.
+
+    Parameters
+    ----------
+    signal : array
+        Raw PPG signal.
+    sampling_rate : int, float, optional
+        Sampling frequency (Hz).
+    show : bool, optional
+        If True, show a summary plot.
+
+    Returns
+    -------
+    ts : array
+        Signal time axis reference (seconds).
+    filtered : array
+        Filtered PPG signal.
+    onsets : array
+        Indices of PPG pulse onsets.
+    heart_rate_ts : array
+        Heart rate time axis reference (seconds).
+    heart_rate : array
+        Instantaneous heart rate (bpm).
+
+    """
+
+    # check inputs
+    if signal is None:
+        raise TypeError("Please specify an input signal.")
+
+    # ensure numpy
+    signal = np.array(signal)
+
+    sampling_rate = float(sampling_rate)
+
+    # filter signal
+    filtered, _, _ = st.filter_signal(signal=signal,
+                                      ftype='butter',
+                                      band='bandpass',
+                                      order=4,
+                                      frequency=[1, 8],
+                                      sampling_rate=sampling_rate)
+
+    # find onsets
+    onsets, _ = find_onsets_elgendi2013(signal=filtered, sampling_rate=sampling_rate)
+
+    # compute heart rate
+    hr_idx, hr = st.get_heart_rate(beats=onsets,
+                                   sampling_rate=sampling_rate,
+                                   smooth=True,
+                                   size=3)
+
+    # get time vectors
+    length = len(signal)
+    T = (length - 1) / sampling_rate
+    ts = np.linspace(0, T, length, endpoint=False)
+    ts_hr = ts[hr_idx]
+
+    # plot
+    if show:
+        plotting.plot_ppg(ts=ts,
+                          raw=signal,
+                          filtered=filtered,
+                          onsets=onsets,
+                          heart_rate_ts=ts_hr,
+                          heart_rate=hr,
+                          path=None,
+                          show=True)
+
+    # output
+    args = (ts, filtered, onsets, ts_hr, hr)
+    names = ('ts', 'filtered', 'onsets', 'heart_rate_ts', 'heart_rate')
+
+    return utils.ReturnTuple(args, names)
+
+def find_onsets_elgendi2013(signal=None, sampling_rate=1000., peakwindow=0.111, beatwindow=0.667, beatoffset=0.02, mindelay=0.3):
+    """
+    Determines onsets of PPG pulses.
+
+    Parameters
+    ----------
+    signal : array
+        Input filtered PPG signal.
+    sampling_rate : int, float, optional
+        Sampling frequency (Hz).
+    peakwindow : float
+        Parameter W1 on referenced article
+        Optimized at 0.111
+    beatwindow : float
+        Parameter W2 on referenced article
+        Optimized at 0.667
+    beatoffset : float
+        Parameter beta on referenced article
+        Optimized at 0.2
+    mindelay : float
+        Minimum delay between peaks.
+        Avoids false positives
+
+    Returns
+    ----------
+    onsets : array
+        Indices of PPG pulse onsets.
+    params : dict
+        Input parameters of the function
+
+
+    References
+    ----------
+    - Elgendi M, Norton I, Brearley M, Abbott D, Schuurmans D (2013) Systolic Peak Detection in
+    Acceleration Photoplethysmograms Measured from Emergency Responders in Tropical Conditions.
+    PLoS ONE 8(10): e76585. doi:10.1371/journal.pone.0076585.
+    
+    Notes
+    ---------------------
+    Optimal ranges for signal filtering (from Elgendi et al. 2013):
+    "Optimization of the beat detector’s spectral window for the lower frequency resulted in a 
+    value within 0.5– 1 Hz with the higher frequency within 7–15 Hz"
+    
+    All the number references below between curly brackets {...} by the code refer to the line numbers of
+    code in "Table 2 Algorithm IV: DETECTOR (PPG signal, F1, F2, W1, W2, b)" from Elgendi et al. 2013 for a
+    better comparison of the algorithm
+    
+    """
+
+    # check inputs
+    if signal is None:
+        raise TypeError("Please specify an input signal.")
+
+    # Create copy of signal (not to modify the original object)
+    signal_copy = np.copy(signal)
+
+    # Truncate to zero and square
+    # {3, 4}
+    signal_copy[signal_copy < 0] = 0
+    squared_signal = signal_copy ** 2
+
+    # Calculate peak detection threshold
+    # {5}
+    ma_peak_kernel = int(np.rint(peakwindow * sampling_rate))
+    ma_peak, _ = st.smoother(squared_signal, kernel="boxcar", size=ma_peak_kernel)
+
+    # {6}
+    ma_beat_kernel = int(np.rint(beatwindow * sampling_rate))
+    ma_beat, _ = st.smoother(squared_signal, kernel="boxcar", size=ma_beat_kernel)
+
+    # Calculate threshold value
+    # {7, 8, 9}
+    thr1 = ma_beat + beatoffset * np.mean(squared_signal)
+
+    # Identify start and end of PPG waves.
+    # {10-16}
+    waves = ma_peak > thr1
+    beg_waves = np.where(np.logical_and(np.logical_not(waves[0:-1]), waves[1:]))[0]
+    end_waves = np.where(np.logical_and(waves[0:-1], np.logical_not(waves[1:])))[0]
+    # Throw out wave-ends that precede first wave-start.
+    end_waves = end_waves[end_waves > beg_waves[0]]
+
+    # Identify systolic peaks within waves (ignore waves that are too short).
+    num_waves = min(beg_waves.size, end_waves.size)
+    # {18}
+    min_len = int(np.rint(peakwindow * sampling_rate))
+    min_delay = int(np.rint(mindelay * sampling_rate))
+    onsets = [0]
+
+    # {19}
+    for i in range(num_waves):
+
+        beg = beg_waves[i]
+        end = end_waves[i]
+        len_wave = end - beg
+
+        # {20, 22, 23}
+        if len_wave < min_len:
+            continue
+
+        # Find local maxima and their prominence within wave span.
+        # {21}
+        data = signal_copy[beg:end]
+        locmax, props = ss.find_peaks(data, prominence=(None, None))
+
+        # If more than one peak
+        if locmax.size > 0:
+            # Identify most prominent local maximum.
+            peak = beg + locmax[np.argmax(props["prominences"])]
+            # Enforce minimum delay between onsets.
+            if peak - onsets[-1] > min_delay:
+                onsets.append(peak)
+
+    onsets.pop(0)
+    onsets = np.array(onsets, dtype='int')
+
+    # output
+    params = {'signal': signal, 'sampling_rate': sampling_rate, 'peakwindow': peakwindow, 'beatwindow': beatwindow, 'beatoffset': beatoffset, 'mindelay': mindelay}
+
+    args = (onsets, params)
+    names = ('onsets', 'params')
+
+    return utils.ReturnTuple(args, names)

--- a/docs/biosppy.signals.rst
+++ b/docs/biosppy.signals.rst
@@ -10,7 +10,17 @@ Modules
 .. contents::
    :local:
 
+.. automodule:: biosppy.signals.abp
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 .. automodule:: biosppy.signals.bvp
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: biosppy.signals.ppg
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ recognition methods geared torwards the analysis of biosignals.
 
 Highlights:
 
--  Support for various biosignals: BVP, ECG, EDA, EEG, EMG, Respiration
+-  Support for various biosignals: PPG, ECG, EDA, EEG, EMG, Respiration
 -  Signal analysis primitives: filtering, frequency analysis
 -  Clustering
 -  Biometrics

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -44,7 +44,7 @@ covered by `biosppy`.
 Blood Volume Pulse
 ------------------
 
-Blood Volume Pulse (BVP) signals are...
+Photoplethysmogram (PPG) signals are...
 
 Electrocardiogram
 -----------------

--- a/examples/ppg.txt
+++ b/examples/ppg.txt
@@ -1,7 +1,7 @@
 # Simple Text Format
 # Sampling Rate (Hz):= 1000.00
 # Resolution:= 12
-# Labels:= BVP
+# Labels:= PPG
 2065.0
 2066.0
 2066.0


### PR DESCRIPTION
By request of prof. Hugo Silva, I made the following changes:

- Main change
   - The onsets in BVP were miscalculated. Added an algorithm by Elgendi et al. 2013 that works well under tropical conditions.
- Module's organization
   - Create a new module ABP for Arterial Blood Pressure (BVP used a method by Zong et al. 2003 to determine the signal onsets; the algorithm was however designed for ABP)
   - The module BVP was renamed as its more standard name: PPG.
   - Leave the BVP module for compatibility with old code
