### PR TITLE
add opencv-python to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scipy==1.2.0
 shortuuid==0.5.0
 six==1.11.0
 joblib==0.11
+opencv-python


### PR DESCRIPTION
`opencv-python` is in [`setup.py`](https://github.com/PIA-Group/BioSPPy/blob/ff04664a3876d59e70bd796011a6e42f1075ef94/setup.py#L44), but NOT in `requirements.txt`.